### PR TITLE
Bonus, throw an extra warning for overriding a shift assignment

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -14,7 +14,7 @@ import {
 	Select,
 	Text,
 } from '@chakra-ui/react'
-import { InfoOutlineIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { InfoOutlineIcon, WarningIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import StoreContext from '../utils/StoreContext'
 
 const ErrorMessage = ({ icon, message }) => {
@@ -40,6 +40,7 @@ export default function Modal({ isOpen, onClose, title }) {
 	const [invalidateForm, setInvalidateForm] = useState(false)
 	const [invalidQual, setInvalidQual] = useState(false)
 	const [invalidTime, setInvalidTime] = useState(false)
+	const [warningOverrideMessage, setWarningOverrideMessage] = useState('')
 	const [checkValidity, setCheckValidity] = useState(false)
 
 	useEffect(() => {
@@ -55,6 +56,17 @@ export default function Modal({ isOpen, onClose, title }) {
 			const getSelectedShift = shiftList.filter((shift) => {
 				return shift.id === shiftInput
 			})[0]
+
+			//check for already assigned nurse
+			const currentShiftNurse = getSelectedShift.nurse_id
+			if (currentShiftNurse) {
+				const currentNurse = nurseList.filter((nurse) => {
+					return nurse.id === currentShiftNurse
+				})[0]
+				setWarningOverrideMessage(
+					`Oops, it looks like ${currentNurse.first_name} is already assigned to this shift. Do you want to override?`
+				)
+			}
 
 			//check for shift vs nurse qualifications
 			const shiftQualification = getSelectedShift.qual_required
@@ -141,6 +153,7 @@ export default function Modal({ isOpen, onClose, title }) {
 		setInvalidQual(false)
 		setInvalidTime(false)
 		setInvalidateForm(false)
+		setWarningOverrideMessage('')
 		setCheckValidity(false)
 		onClose()
 	}
@@ -273,6 +286,12 @@ export default function Modal({ isOpen, onClose, title }) {
 							<ErrorMessage
 								icon={WarningTwoIcon}
 								message={error}
+							/>
+						)}
+						{warningOverrideMessage && (
+							<ErrorMessage
+								icon={WarningIcon}
+								message={warningOverrideMessage}
 							/>
 						)}
 

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -17,11 +17,11 @@ import {
 import { InfoOutlineIcon, WarningIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import StoreContext from '../utils/StoreContext'
 
-const ErrorMessage = ({ icon, message }) => {
+const ErrorMessage = ({ color, icon, message }) => {
 	const Icon = icon
 	return (
 		<Flex align='center' mt={4}>
-			<Icon h={4} w={4} />
+			<Icon color={color} h={4} w={4} />
 			<Text pl={2}>{message}</Text>
 		</Flex>
 	)
@@ -291,6 +291,7 @@ export default function Modal({ isOpen, onClose, title }) {
 						{warningOverrideMessage && (
 							<ErrorMessage
 								icon={WarningIcon}
+								color='orange'
 								message={warningOverrideMessage}
 							/>
 						)}


### PR DESCRIPTION
Adding the ability to throw an error when overriding a shift that already has a nurse assigned to it. Does not stop the form from submitting, just throws a friendly reminder.
